### PR TITLE
Do Not Report File Provider Items as Shared

### DIFF
--- a/Sources/NextcloudFileProviderKit/Item/Item.swift
+++ b/Sources/NextcloudFileProviderKit/Item/Item.swift
@@ -151,11 +151,11 @@ public class Item: NSObject, NSFileProviderItem {
     }
 
     public var isShared: Bool {
-        !metadata.shareType.isEmpty
+        false // !metadata.shareType.isEmpty // Interim solution to counteract Finder misleadingly displaying shared items with an iCloud branded banner.
     }
 
     public var isSharedByCurrentUser: Bool {
-        isShared && metadata.ownerId == account.id
+        false // isShared && metadata.ownerId == account.id // Interim solution to counteract Finder misleadingly displaying shared items with an iCloud branded banner.
     }
 
     public var ownerNameComponents: PersonNameComponents? {

--- a/Tests/NextcloudFileProviderKitTests/ItemPropertyTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/ItemPropertyTests.swift
@@ -866,8 +866,8 @@ final class ItemPropertyTests: XCTestCase {
             remoteInterface: MockRemoteInterface(),
             dbManager: Self.dbManager
         )
-        XCTAssertTrue(sharedItem.isShared)
-        XCTAssertTrue(sharedItem.isSharedByCurrentUser)
+        XCTAssertFalse(sharedItem.isShared)
+        XCTAssertFalse(sharedItem.isSharedByCurrentUser)
         XCTAssertNil(sharedItem.ownerNameComponents) // Should be nil if it is shared by us
 
         var sharedByOtherMetadata = sharedMetadata
@@ -880,11 +880,9 @@ final class ItemPropertyTests: XCTestCase {
             remoteInterface: MockRemoteInterface(),
             dbManager: Self.dbManager
         )
-        XCTAssertTrue(sharedByOtherTime.isShared)
+        XCTAssertFalse(sharedByOtherTime.isShared)
         XCTAssertFalse(sharedByOtherTime.isSharedByCurrentUser)
-        XCTAssertNotNil(sharedByOtherTime.ownerNameComponents)
-        XCTAssertEqual(sharedByOtherTime.ownerNameComponents?.givenName, "Claudio")
-        XCTAssertEqual(sharedByOtherTime.ownerNameComponents?.familyName, "Cambra")
+        XCTAssertNil(sharedByOtherTime.ownerNameComponents)
 
         var notSharedMetadata =
             SendableItemMetadata(ocId: "test-id", fileName: "test.txt", account: Self.account)


### PR DESCRIPTION
Interim solution to counteract Finder misleadingly displaying shared items with an iCloud branded banner.