### PR TITLE
Assert Database Directory

### DIFF
--- a/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
+++ b/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
@@ -71,7 +71,7 @@ public final class FilesDatabaseManager: Sendable {
 
         let manager = FileManager.default
 
-        guard let extensionData = pathForFileProviderExtData() else {
+        guard let extensionData = urlForFileProviderExtensionData() else {
             Self.logger.fault("Failed to resolve the file provider extension data directory!")
             assertionFailure("Failed to resolve the file provider extension data directory!")
             return manager.temporaryDirectory // Only to satisfy the non-optional return type. The extension is unusable at this point anyway.

--- a/Sources/NextcloudFileProviderKit/Utilities/LocalFiles.swift
+++ b/Sources/NextcloudFileProviderKit/Utilities/LocalFiles.swift
@@ -51,14 +51,17 @@ public func urlForFileProviderExtensionData() -> URL? {
         }
     }
 
-    return try! FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+    do {
+        return try FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+    } catch {
+        lfuLogger.error("Failed to get URL for application support directory in user mask!")
+        return nil
+    }
 }
 
 public func pathForFileProviderTempFilesForDomain(_ domain: NSFileProviderDomain) throws -> URL? {
     guard let fpManager = NSFileProviderManager(for: domain) else {
-        lfuLogger.error(
-            "Unable to get file provider manager for domain: \(domain.displayName, privacy: .public)"
-        )
+        lfuLogger.error("Unable to get file provider manager for domain: \(domain.displayName, privacy: .public)")
         throw NSFileProviderError(.providerNotFound)
     }
 

--- a/Sources/NextcloudFileProviderKit/Utilities/LocalFiles.swift
+++ b/Sources/NextcloudFileProviderKit/Utilities/LocalFiles.swift
@@ -24,12 +24,8 @@ fileprivate let lfuLogger = Logger(subsystem: Logger.subsystem, category: "local
 /// - Returns: Container URL for the extension's app group.
 ///
 public func pathForAppGroupContainer() -> URL? {
-    guard let appGroupIdentifier = Bundle.main.object(
-        forInfoDictionaryKey: "NCFPKAppGroupIdentifier"
-    ) as? String else {
-        lfuLogger.critical(
-            "Could not get app group container url as Info.plist missing NCFPKAppGroupIdentifier!"
-        )
+    guard let appGroupIdentifier = Bundle.main.object(forInfoDictionaryKey: "NCFPKAppGroupIdentifier") as? String else {
+        lfuLogger.critical("Could not get app group container URL due to missing value for NCFPKAppGroupIdentifier key in Info.plist!")
         return nil
     }
 

--- a/Tests/NextcloudFileProviderKitTests/AccountTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/AccountTests.swift
@@ -9,7 +9,7 @@ import Foundation
 import XCTest
 @testable import NextcloudFileProviderKit
 
-final class AccountTests: XCTestCase {
+final class AccountTests: NextcloudFileProviderKitTestCase {
     func testInitializationDirect() {
         let user = "user"
         let userId = "userId"

--- a/Tests/NextcloudFileProviderKitTests/ChunkedArrayTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/ChunkedArrayTests.swift
@@ -8,7 +8,7 @@
 @testable import NextcloudFileProviderKit
 import XCTest
 
-final class ChunkedArrayTests: XCTestCase {
+final class ChunkedArrayTests: NextcloudFileProviderKitTestCase {
     // MARK: - chunked(into:)
     func testChunkedEmptyArray() {
         let emptyArray: [Int] = []

--- a/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
@@ -12,7 +12,7 @@ import XCTest
 @testable import TestInterface
 @testable import NextcloudFileProviderKit
 
-final class EnumeratorTests: XCTestCase {
+final class EnumeratorTests: NextcloudFileProviderKitTestCase {
     static let account = Account(
         user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
     )
@@ -28,9 +28,7 @@ final class EnumeratorTests: XCTestCase {
     var remoteTrashItemB: MockRemoteItem!
     var remoteTrashItemC: MockRemoteItem!
 
-    static let dbManager = FilesDatabaseManager(
-        realmConfig: .defaultConfiguration, account: account
-    )
+    static let dbManager = FilesDatabaseManager(account: account, databaseDirectory: makeDatabaseDirectory())
 
     override func setUp() {
         super.setUp()

--- a/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
@@ -13,15 +13,13 @@ import UniformTypeIdentifiers
 import XCTest
 @testable import NextcloudFileProviderKit
 
-final class ItemCreateTests: XCTestCase {
+final class ItemCreateTests: NextcloudFileProviderKitTestCase {
     static let account = Account(
         user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
     )
 
     var rootItem: MockRemoteItem!
-    static let dbManager = FilesDatabaseManager(
-        realmConfig: .defaultConfiguration, account: account
-    )
+    static let dbManager = FilesDatabaseManager(account: account, databaseDirectory: makeDatabaseDirectory())
 
     override func setUp() {
         super.setUp()

--- a/Tests/NextcloudFileProviderKitTests/ItemDeleteTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/ItemDeleteTests.swift
@@ -12,15 +12,13 @@ import TestInterface
 import XCTest
 @testable import NextcloudFileProviderKit
 
-final class ItemDeleteTests: XCTestCase {
+final class ItemDeleteTests: NextcloudFileProviderKitTestCase {
     static let account = Account(
         user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
     )
     lazy var rootItem = MockRemoteItem.rootItem(account: Self.account)
     lazy var rootTrashItem = MockRemoteItem.rootTrashItem(account: Self.account)
-    static let dbManager = FilesDatabaseManager(
-        realmConfig: .defaultConfiguration, account: account
-    )
+    static let dbManager = FilesDatabaseManager(account: account, databaseDirectory: makeDatabaseDirectory())
 
     override func setUp() {
         super.setUp()

--- a/Tests/NextcloudFileProviderKitTests/ItemFetchTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/ItemFetchTests.swift
@@ -12,15 +12,13 @@ import TestInterface
 import XCTest
 @testable import NextcloudFileProviderKit
 
-final class ItemFetchTests: XCTestCase {
+final class ItemFetchTests: NextcloudFileProviderKitTestCase {
     static let account = Account(
         user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
     )
 
     lazy var rootItem = MockRemoteItem.rootItem(account: Self.account)
-    static let dbManager = FilesDatabaseManager(
-        realmConfig: .defaultConfiguration, account: account
-    )
+    static let dbManager = FilesDatabaseManager(account: account, databaseDirectory: makeDatabaseDirectory())
 
     override func setUp() {
         super.setUp()

--- a/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
@@ -13,7 +13,7 @@ import UniformTypeIdentifiers
 import XCTest
 @testable import NextcloudFileProviderKit
 
-final class ItemModifyTests: XCTestCase {
+final class ItemModifyTests: NextcloudFileProviderKitTestCase {
     static let account = Account(
         user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
     )
@@ -27,9 +27,7 @@ final class ItemModifyTests: XCTestCase {
     var remoteTrashFolder: MockRemoteItem!
     var remoteTrashFolderChildItem: MockRemoteItem!
 
-    static let dbManager = FilesDatabaseManager(
-        realmConfig: .defaultConfiguration, account: account
-    )
+    static let dbManager = FilesDatabaseManager(account: account, databaseDirectory: makeDatabaseDirectory())
 
     override func setUp() {
         super.setUp()

--- a/Tests/NextcloudFileProviderKitTests/ItemPropertyTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/ItemPropertyTests.swift
@@ -13,13 +13,11 @@ import UniformTypeIdentifiers
 import XCTest
 @testable import NextcloudFileProviderKit
 
-final class ItemPropertyTests: XCTestCase {
+final class ItemPropertyTests: NextcloudFileProviderKitTestCase {
     static let account = Account(
         user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
     )
-    static let dbManager = FilesDatabaseManager(
-        realmConfig: .defaultConfiguration, account: account
-    )
+    static let dbManager = FilesDatabaseManager(account: account, databaseDirectory: makeDatabaseDirectory())
 
     override func setUp() {
         super.setUp()

--- a/Tests/NextcloudFileProviderKitTests/MaterialisedEnumerationObserverTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/MaterialisedEnumerationObserverTests.swift
@@ -13,7 +13,7 @@ import RealmSwift
 import TestInterface
 import XCTest
 
-final class MaterialisedEnumerationObserverTests: XCTestCase {
+final class MaterialisedEnumerationObserverTests: NextcloudFileProviderKitTestCase {
     static let account = Account(
         user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
     )
@@ -24,9 +24,7 @@ final class MaterialisedEnumerationObserverTests: XCTestCase {
     }
 
     func testMaterialisedObserverWithNoPreexistingState() async {
-        let dbManager = FilesDatabaseManager(
-            realmConfig: .defaultConfiguration, account: Self.account
-        )
+        let dbManager = FilesDatabaseManager(account: Self.account, databaseDirectory: makeDatabaseDirectory())
         // The database is intentionally left empty.
 
         let remoteInterface = MockRemoteInterface()
@@ -98,9 +96,7 @@ final class MaterialisedEnumerationObserverTests: XCTestCase {
         dirD.directory = true
         dirD.visitedDirectory = true // Was materialised
 
-        let dbManager = FilesDatabaseManager(
-            realmConfig: .defaultConfiguration, account: Self.account
-        )
+        let dbManager = FilesDatabaseManager(account: Self.account, databaseDirectory: makeDatabaseDirectory())
         dbManager.addItemMetadata(itemA)
         dbManager.addItemMetadata(itemB)
         dbManager.addItemMetadata(itemC)

--- a/Tests/NextcloudFileProviderKitTests/NKFileExtensionTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/NKFileExtensionTests.swift
@@ -10,7 +10,7 @@ import FileProvider
 import NextcloudKit
 @testable import NextcloudFileProviderKit
 
-final class NKFileExtensionsTests: XCTestCase {
+final class NKFileExtensionsTests: NextcloudFileProviderKitTestCase {
 
     static let account = Account(
         user: "testUser",

--- a/Tests/NextcloudFileProviderKitTests/NextcloudFileProviderKitTestCase.swift
+++ b/Tests/NextcloudFileProviderKitTests/NextcloudFileProviderKitTestCase.swift
@@ -1,0 +1,25 @@
+import XCTest
+
+///
+/// Common base class for all tests in this target.
+///
+class NextcloudFileProviderKitTestCase: XCTestCase {
+    ///
+    /// Create a unique and temporary directory for Realm database testing purposes.
+    ///
+    /// - Returns: A URL pointing to a temporary directory which also contains a UUID to distinguish it clearly from any other calls.
+    ///
+    static func makeDatabaseDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+
+        return url
+    }
+
+    ///
+    /// Instance wrapper for ``makeDatabaseDirectory`` for convenience and brevity.
+    ///
+    func makeDatabaseDirectory() -> URL {
+        Self.makeDatabaseDirectory()
+    }
+}

--- a/Tests/NextcloudFileProviderKitTests/RemoteChangeObserverEtagOptimizationTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/RemoteChangeObserverEtagOptimizationTests.swift
@@ -13,7 +13,7 @@ import XCTest
 @testable import NextcloudFileProviderKit
 
 @available(macOS 14.0, iOS 17.0, *)
-final class RemoteChangeObserverEtagOptimizationTests: XCTestCase {
+final class RemoteChangeObserverEtagOptimizationTests: NextcloudFileProviderKitTestCase {
     static let account = Account(
         user: "testUser", id: "testUserId", serverUrl: "localhost", password: "abcd"
     )
@@ -23,7 +23,7 @@ final class RemoteChangeObserverEtagOptimizationTests: XCTestCase {
     
     override func setUp() {
         Realm.Configuration.defaultConfiguration.inMemoryIdentifier = name
-        dbManager = FilesDatabaseManager(realmConfig: .defaultConfiguration, account: Self.account)
+        dbManager = FilesDatabaseManager(account: Self.account, databaseDirectory: makeDatabaseDirectory())
         mockRemoteInterface = MockRemoteInterface(rootItem: MockRemoteItem.rootItem(account: Self.account))
     }
     

--- a/Tests/NextcloudFileProviderKitTests/RemoteChangeObserverTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/RemoteChangeObserverTests.swift
@@ -20,14 +20,12 @@ fileprivate let serverUrl = "localhost"
 fileprivate let password = "abcd"
 
 @available(macOS 14.0, iOS 17.0, *)
-final class RemoteChangeObserverTests: XCTestCase {
+final class RemoteChangeObserverTests: NextcloudFileProviderKitTestCase {
     static let timeout = 5_000 // tries
     static let account = Account(
         user: username, id: userId, serverUrl: serverUrl, password: password
     )
-    static let dbManager = FilesDatabaseManager(
-        realmConfig: .defaultConfiguration, account: account
-    )
+    static let dbManager = FilesDatabaseManager(account: account, databaseDirectory: makeDatabaseDirectory())
     static let notifyPushServer = MockNotifyPushServer(
         host: serverUrl,
         port: 8888,

--- a/Tests/NextcloudFileProviderKitTests/UploadTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/UploadTests.swift
@@ -10,11 +10,9 @@ import TestInterface
 import XCTest
 @testable import NextcloudFileProviderKit
 
-final class UploadTests: XCTestCase {
+final class UploadTests: NextcloudFileProviderKitTestCase {
     static let account = Account(user: "user", id: "id", serverUrl: "test.cloud.com", password: "1234")
-    static let dbManager = FilesDatabaseManager(
-        realmConfig: .defaultConfiguration, account: account
-    )
+    static let dbManager = FilesDatabaseManager(account: account, databaseDirectory: makeDatabaseDirectory())
 
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
Ensure existence of required file provider extension database directory.

This refactors and consolidates the initialization of the database manager. It includes verification and creation of the required directory Sometimes the file provider extension crashed because it could not create the Realm database files because of the assumed directory not existing. The directory is directly related to and can be considered owned by the database manager. Hence it should also manage it.

The logging has been extended and assertion failures introduced to pinpoint irrecoverable dysfunction.

The tests have been updated accordingly and now also use unique temporary working directories by default.

---

I hoped that this fixes a problem but sadly it does not, hence it is labelled as an enhancement. The crash of the file provider extension on process launch due to failed directory creation for Realm appears to be of different nature, something related to sandboxing and privileges, I assume.