### PR TITLE
fix: Add writing capability for directories with CK permission

### DIFF
--- a/Sources/NextcloudFileProviderKit/Item/Item.swift
+++ b/Sources/NextcloudFileProviderKit/Item/Item.swift
@@ -49,6 +49,9 @@ public class Item: NSObject, NSFileProviderItem {
                     capabilities.insert(.allowsAddingSubItems)
                 }
             }
+            if permissions.contains("CK"), metadata.directory { // Folder not changeable but adding sub-files & -folders
+                capabilities.insert(.allowsWriting)
+            }
         }
         // .allowsEvicting deprecated on macOS 13.0+, use contentPolicy instead
         if #unavailable(macOS 13.0), !metadata.keepDownloaded {


### PR DESCRIPTION
Team Folders have the permission RMGCK

C = may add files, and K = may add subdirectories

currently they are shown as locked in VFS because current codebase expects a 'W'