### PR TITLE
Fixed lock file handling and improved logging

### DIFF
--- a/Sources/NextcloudFileProviderKit/Database/SchemaVersion.swift
+++ b/Sources/NextcloudFileProviderKit/Database/SchemaVersion.swift
@@ -8,4 +8,5 @@ enum SchemaVersion: UInt64 {
     case initial = 100
     case deletedLocalFileMetadata = 200
     case addedLockTokenPropertyToRealmItemMetadata = 201
+    case addedIsLockFileOfLocalOriginToRealmItemMetadata = 202
 }

--- a/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+SyncEngine.swift
+++ b/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+SyncEngine.swift
@@ -120,7 +120,6 @@ extension Enumerator {
         nextPage: EnumeratorPageResponse?,
         readError: NKError?
     ) {
-        let ncKitAccount = account.ncKitAccount
         let logger = FileProviderLogger(category: "Enumerator", log: log)
 
         logger.debug("Starting to read server URL.", [.url: serverUrl])

--- a/Sources/NextcloudFileProviderKit/Enumeration/MaterialisedEnumerationObserver.swift
+++ b/Sources/NextcloudFileProviderKit/Enumeration/MaterialisedEnumerationObserver.swift
@@ -80,7 +80,7 @@ public class MaterialisedEnumerationObserver: NSObject, NSFileProviderEnumeratio
                 newMaterialisedIds.insert(enumeratedId)
 
                 guard var metadata = dbManager.itemMetadata(ocId: enumeratedId) else {
-                    logger.error("No metadata for \(enumeratedId) found", [.ocId: enumeratedId])
+                    logger.error("No metadata for enumerated item found.", [.item: enumeratedId])
                     continue
                 }
 

--- a/Sources/NextcloudFileProviderKit/Item/Item+Fetch.swift
+++ b/Sources/NextcloudFileProviderKit/Item/Item+Fetch.swift
@@ -297,28 +297,13 @@ public extension Item {
         return (localPath, fpItem, nil)
     }
 
-    func fetchThumbnail(
-        size: CGSize, domain: NSFileProviderDomain? = nil
-    ) async -> (Data?, Error?) {
+    func fetchThumbnail(size: CGSize, domain: NSFileProviderDomain? = nil) async -> (Data?, Error?) {
         guard let thumbnailUrl = metadata.thumbnailUrl(size: size) else {
-            logger.debug(
-                """
-                Unknown thumbnail URL for: \(self.itemIdentifier.rawValue)
-                fileName: \(self.filename)
-                """
-            )
-            return (
-                nil,
-                NSError.fileProviderErrorForNonExistentItem(withIdentifier: self.itemIdentifier)
-            )
+            logger.debug("Unknown thumbnail URL.", [.item: self.itemIdentifier, .name: self.filename])
+            return (nil, NSError.fileProviderErrorForNonExistentItem(withIdentifier: self.itemIdentifier))
         }
 
-        logger.debug(
-            """
-            Fetching thumbnail for: \(self.filename)
-            at (\(thumbnailUrl))
-            """
-        )
+        logger.debug("Fetching thumbnail.", [.name: self.filename, .url: thumbnailUrl])
 
         let (_, data, error) = await remoteInterface.downloadThumbnail(
             url: thumbnailUrl, account: account, options: .init(), taskHandler: { task in
@@ -333,16 +318,7 @@ public extension Item {
         )
 
         if error != .success {
-            logger.error(
-                """
-                Could not acquire thumbnail for item with identifier: 
-                \(self.itemIdentifier.rawValue)
-                and fileName: \(self.filename)
-                at \(thumbnailUrl)
-                error: \(error.errorCode)
-                \(error.errorDescription)
-                """
-            )
+            logger.error("Could not acquire thumbnail.", [.item: self.itemIdentifier, .name: self.filename, .url: thumbnailUrl, .error: error])
         }
 
         return (data, error.fileProviderError(

--- a/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
+++ b/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
@@ -679,6 +679,8 @@ public extension Item {
 
         let newServerUrlFileName = newParentItemRemoteUrl + "/" + itemTarget.filename
 
+        logger.debug("About to modify item.", [.ocId: ocId])
+        
         logger.debug(
             """
             About to modify item with identifier: \(ocId)

--- a/Sources/NextcloudFileProviderKit/Log/FileProviderLogMessage.swift
+++ b/Sources/NextcloudFileProviderKit/Log/FileProviderLogMessage.swift
@@ -33,14 +33,9 @@ public struct FileProviderLogMessage: Encodable {
     public let message: String
 
     ///
-    /// As used with `Logger` of the `os` framework.
-    ///
-    public let subsystem: String
-
-    ///
     /// Custom initializer to support arbitrary types as detail values.
     ///
-    init(category: String, date: String, details: [FileProviderLogDetailKey : Any?], level: String, message: String, subsystem: String) {
+    init(category: String, date: String, details: [FileProviderLogDetailKey : Any?], level: String, message: String) {
         self.category = category
         self.date = date
 
@@ -53,6 +48,5 @@ public struct FileProviderLogMessage: Encodable {
         self.details = transformedDetails
         self.level = level
         self.message = message
-        self.subsystem = subsystem
     }
 }

--- a/Sources/NextcloudFileProviderKit/Metadata/ItemMetadata.swift
+++ b/Sources/NextcloudFileProviderKit/Metadata/ItemMetadata.swift
@@ -51,6 +51,7 @@ public protocol ItemMetadata: Equatable {
     var hidden: Bool { get set }
     var iconName: String { get set }
     var iconUrl: String { get set }
+    var isLockFileOfLocalOrigin: Bool { get set }
     var mountType: String { get set }
     var name: String { get set }  // for unifiedSearch is the provider.id
     var note: String { get set }

--- a/Sources/NextcloudFileProviderKit/Metadata/RealmItemMetadata.swift
+++ b/Sources/NextcloudFileProviderKit/Metadata/RealmItemMetadata.swift
@@ -35,6 +35,7 @@ internal class RealmItemMetadata: Object, ItemMetadata {
     @Persisted public var hidden = false
     @Persisted public var iconName = ""
     @Persisted public var iconUrl = ""
+    @Persisted public var isLockFileOfLocalOrigin: Bool = false
     @Persisted public var livePhotoFile: String?
     @Persisted public var mountType = ""
     @Persisted public var name = ""  // for unifiedSearch is the provider.id
@@ -135,6 +136,7 @@ internal class RealmItemMetadata: Object, ItemMetadata {
         self.hidden = value.hidden
         self.iconName = value.iconName
         self.iconUrl = value.iconUrl
+        self.isLockFileOfLocalOrigin = value.isLockFileOfLocalOrigin
         self.livePhotoFile = value.livePhotoFile
         self.mountType = value.mountType
         self.name = value.name

--- a/Sources/NextcloudFileProviderKit/Metadata/SendableItemMetadata.swift
+++ b/Sources/NextcloudFileProviderKit/Metadata/SendableItemMetadata.swift
@@ -35,6 +35,12 @@ public struct SendableItemMetadata: ItemMetadata, Sendable {
     public var hidden: Bool
     public var iconName: String
     public var iconUrl: String
+    
+    ///
+    /// This is a lock file which was created on the local device and not introduced through synchronization with the server.
+    ///
+    public var isLockFileOfLocalOrigin: Bool
+
     public var mountType: String
     public var name: String
     public var note: String
@@ -102,6 +108,7 @@ public struct SendableItemMetadata: ItemMetadata, Sendable {
         hidden: Bool = false,
         iconName: String = "",
         iconUrl: String = "",
+        isLockfileOfLocalOrigin: Bool = false,
         livePhotoFile: String? = nil,
         mountType: String = "",
         name: String = "",
@@ -168,6 +175,7 @@ public struct SendableItemMetadata: ItemMetadata, Sendable {
         self.hidden = hidden
         self.iconName = iconName
         self.iconUrl = iconUrl
+        self.isLockFileOfLocalOrigin = isLockfileOfLocalOrigin
         self.livePhotoFile = livePhotoFile
         self.mountType = mountType
         self.name = name
@@ -236,6 +244,7 @@ public struct SendableItemMetadata: ItemMetadata, Sendable {
         self.hidden = value.hidden
         self.iconName = value.iconName
         self.iconUrl = value.iconUrl
+        self.isLockFileOfLocalOrigin = value.isLockFileOfLocalOrigin
         self.livePhotoFile = value.livePhotoFile
         self.mountType = value.mountType
         self.name = value.name

--- a/Sources/NextcloudFileProviderKit/Utilities/LocalFiles.swift
+++ b/Sources/NextcloudFileProviderKit/Utilities/LocalFiles.swift
@@ -59,9 +59,8 @@ public func isLockFileName(_ filename: String) -> Bool {
 ///
 public func originalFileName(fromLockFileName lockFilename: String, dbManager: FilesDatabaseManager) -> String? {
     let logger = FileProviderLogger(category: "LocalFiles", log: dbManager.logger.log)
-    logger.debug("Called originalFileName with lock filename: \(lockFilename)")
-
     var targetFileSuffix = lockFilename
+    
     if lockFilename.hasPrefix("~$") {
         let index = lockFilename.index(lockFilename.startIndex, offsetBy: 2)
         targetFileSuffix = String(lockFilename[index...])
@@ -77,18 +76,18 @@ public func originalFileName(fromLockFileName lockFilename: String, dbManager: F
         targetFileSuffix = String(lockFilename[..<sbRange.lowerBound])
     }
 
-    logger.debug("Target suffix is: \(targetFileSuffix)")
-
+    logger.debug("Target suffix is \"\(targetFileSuffix)\".")
     let itemsMatchingMetadata = dbManager.itemsMetadataByFileNameSuffix(suffix: targetFileSuffix)
+    
     for file in itemsMatchingMetadata {
         let potentialOriginalFile = file.fileName
         
         if lockFilename == potentialOriginalFile {
-            logger.debug("Lock filename \(lockFilename) is the same as filename found in db \(potentialOriginalFile)")
+            logger.debug("Lock filename \"\(lockFilename)\" is the same as filename found in database: \"\(potentialOriginalFile)\".")
             continue;
         }
 
-        logger.debug("Matched lock filename \(lockFilename) to original filename \(potentialOriginalFile)")
+        logger.debug("Matched lock filename \"\(lockFilename)\" to original filename \"\(potentialOriginalFile)\".")
         return potentialOriginalFile
     }
     

--- a/Tests/NextcloudFileProviderKitTests/FilesDatabaseManagerTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/FilesDatabaseManagerTests.swift
@@ -854,7 +854,7 @@ final class FilesDatabaseManagerTests: NextcloudFileProviderKitTestCase {
 
         // Create the old Realm configuration and insert test objects.
         // Use most recent schema and the appropriate object types.
-        let oldConfig = Realm.Configuration(fileURL: oldRealmURL, schemaVersion: SchemaVersion.addedLockTokenPropertyToRealmItemMetadata.rawValue, objectTypes: [RealmItemMetadata.self, RemoteFileChunk.self])
+        let oldConfig = Realm.Configuration(fileURL: oldRealmURL, schemaVersion: SchemaVersion.addedIsLockFileOfLocalOriginToRealmItemMetadata.rawValue, objectTypes: [RealmItemMetadata.self, RemoteFileChunk.self])
         let oldRealm = try Realm(configuration: oldConfig)
 
         // Create test objects
@@ -880,7 +880,7 @@ final class FilesDatabaseManagerTests: NextcloudFileProviderKitTestCase {
 
         // Prepare a new Realm configuration for the target per‑account database.
         let newRealmURL = temporaryDirectory.appendingPathComponent("new.realm")
-        let newConfig = Realm.Configuration(fileURL: newRealmURL, schemaVersion: SchemaVersion.addedLockTokenPropertyToRealmItemMetadata.rawValue, objectTypes: [RealmItemMetadata.self, RemoteFileChunk.self])
+        let newConfig = Realm.Configuration(fileURL: newRealmURL, schemaVersion: SchemaVersion.addedIsLockFileOfLocalOriginToRealmItemMetadata.rawValue, objectTypes: [RealmItemMetadata.self, RemoteFileChunk.self])
 
         // Call the initializer that performs the migration.
         // It will search for the old database at:
@@ -932,7 +932,7 @@ final class FilesDatabaseManagerTests: NextcloudFileProviderKitTestCase {
         // Insert initial objects into the old realm
         let oldConfig = Realm.Configuration(
             fileURL: oldRealmURL,
-            schemaVersion: SchemaVersion.addedLockTokenPropertyToRealmItemMetadata.rawValue,
+            schemaVersion: SchemaVersion.addedIsLockFileOfLocalOriginToRealmItemMetadata.rawValue,
             objectTypes: [RealmItemMetadata.self, RemoteFileChunk.self]
         )
         let oldRealm = try Realm(configuration: oldConfig)
@@ -958,7 +958,7 @@ final class FilesDatabaseManagerTests: NextcloudFileProviderKitTestCase {
         let newRealmURL = tempDir.appendingPathComponent("new.realm")
         let newConfig = Realm.Configuration(
             fileURL: newRealmURL,
-            schemaVersion: SchemaVersion.addedLockTokenPropertyToRealmItemMetadata.rawValue,
+            schemaVersion: SchemaVersion.addedIsLockFileOfLocalOriginToRealmItemMetadata.rawValue,
             objectTypes: [RealmItemMetadata.self, RemoteFileChunk.self]
         )
 

--- a/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
+++ b/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
@@ -633,11 +633,7 @@ final class ItemCreateTests: NextcloudFileProviderKitTestCase {
         XCTAssertNotNil(createdItem)
         XCTAssertEqual(createdItem?.isUploaded, false)
         XCTAssertEqual(createdItem?.isDownloaded, true)
-        if #available(macOS 13.0, *) {
-            XCTAssertEqual(error as? NSFileProviderError, NSFileProviderError(.excludedFromSync))
-        } else {
-            XCTAssertNil(error)
-        }
+        XCTAssertNil(error)
         XCTAssertNotNil(Self.dbManager.itemMetadata(ocId: lockFileMetadata.ocId))
         XCTAssertTrue(targetRemote.locked)
     }
@@ -718,7 +714,8 @@ final class ItemCreateTests: NextcloudFileProviderKitTestCase {
         )
 
         XCTAssertNil(createdItem)
-        XCTAssertNil(error)
+        let unwrappedError = try XCTUnwrap(error) as? NSFileProviderError
+        XCTAssertEqual(unwrappedError, NSFileProviderError(.cannotSynchronize))
         XCTAssertNil(Self.dbManager.itemMetadata(ocId: lockFileMetadata.ocId))
         XCTAssertFalse(targetRemote.locked)
     }


### PR DESCRIPTION
Locking:
- Added a boolean flag to metadata items which indicates whether they are locally created lock files or not. This is required for correct handling in some places.
- Changed database schema version.
- Lock files are now not excluded from synchronization but pretended to be synchronized.
- On following synchronizations, they are excluded from local deletion due to not being found on the server.
- Also, they are ignored in the materialized item enumeration to avoid unnecessary server requests.

Logging:
- Removed subsystem property in file provider domain log messages because it is always the same anyway.
- Improved date formatting of file provider domain log messages.
- Messages are written to the unified logging system again in debug configuration builds.
- Messages with debug level are not written to log files unless it is a debug configuration build.
- Refined encoding of supported log detail types.

Key changes of this commit:
- FilesDatabaseManager.swift:661
- RemoteChangeObserver.swift:474
- Item+Delete.swift:29
- Item+LockFile.swift:137